### PR TITLE
Download messages

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub mod sqs;

--- a/src/commands/sqs/common.rs
+++ b/src/commands/sqs/common.rs
@@ -2,10 +2,10 @@ use std::env;
 use std::error::Error;
 
 pub fn construct_queue_url(queue_name: &str) -> Result<String, Box<dyn Error>> {
-  Ok(String::from(format!(
-      "https://sqs.{region}.amazonaws.com/{account}/{queue_name}",
-      region = env::var("AWS_DEFAULT_REGION").expect("AWS REGION NOT FOUND"),
-      account = env::var("AWS_ACCOUNT").expect("AWS ACCOUNT NOT FOUND"),
-      queue_name = queue_name
-  )))
+  Ok(format!(
+    "https://sqs.{region}.amazonaws.com/{account}/{queue_name}",
+    region = env::var("AWS_DEFAULT_REGION").expect("AWS REGION NOT FOUND"),
+    account = env::var("AWS_ACCOUNT").expect("AWS ACCOUNT NOT FOUND"),
+    queue_name = queue_name
+  ))
 }

--- a/src/commands/sqs/common.rs
+++ b/src/commands/sqs/common.rs
@@ -1,0 +1,11 @@
+use std::env;
+use std::error::Error;
+
+pub fn construct_queue_url(queue_name: &str) -> Result<String, Box<dyn Error>> {
+  Ok(String::from(format!(
+      "https://sqs.{region}.amazonaws.com/{account}/{queue_name}",
+      region = env::var("AWS_DEFAULT_REGION").expect("AWS REGION NOT FOUND"),
+      account = env::var("AWS_ACCOUNT").expect("AWS ACCOUNT NOT FOUND"),
+      queue_name = queue_name
+  )))
+}

--- a/src/commands/sqs/download_message.rs
+++ b/src/commands/sqs/download_message.rs
@@ -1,0 +1,39 @@
+use std::error::Error;
+use rusoto_sqs::*;
+use super::common::construct_queue_url;
+use super::models::Message::RawsMessage;
+use super::list_message::retrieve_all_messages;
+
+pub fn handler(sqs: SqsClient, queue_name: &str) -> Result<Vec<String>, Box<dyn Error>> {
+  let request = ReceiveMessageRequest {
+    queue_url: construct_queue_url(queue_name)?,
+    max_number_of_messages: Some(10),
+    ..Default::default()
+  };
+  let messages = retrieve_all_messages(&sqs, &request, vec!());
+  messages
+    .iter()
+    .map(|m: &RawsMessage| {
+      m.receipt_handle
+      .iter()
+      .map(|h| {
+        delete_message(&sqs, queue_name, h.into())
+      })
+    })
+    .for_each(drop);
+    
+  Ok(vec!())
+}
+
+fn delete_message(sqs: &SqsClient, queue_name: &str, receipt_handle: String) -> Result<(), Box<dyn Error>> {
+  let delete_message_request = DeleteMessageRequest {
+      queue_url: construct_queue_url(queue_name)?,
+      receipt_handle
+  };
+
+  sqs
+    .delete_message(delete_message_request)
+    .sync()?;
+
+  Ok(())
+}

--- a/src/commands/sqs/download_message.rs
+++ b/src/commands/sqs/download_message.rs
@@ -1,4 +1,6 @@
 use std::error::Error;
+use std::fs::File;
+use std::io::Write;
 use rusoto_sqs::*;
 use super::common::construct_queue_url;
 use super::models::Message::RawsMessage;
@@ -11,8 +13,11 @@ pub fn handler(sqs: SqsClient, queue_name: &str) -> Result<Vec<String>, Box<dyn 
     ..Default::default()
   };
   let messages = retrieve_all_messages(&sqs, &request, vec!());
-  // For each message, get the receipt handle, call the delete message
-  // and print the message body
+  // For each message, get the receipt handle, call the delete message,
+  // print the message body and save it to a file
+  let path = "sqs_messages.txt";
+  let mut output = File::create(path)?;
+
   messages
     .iter()
     .map(|m: &RawsMessage| {
@@ -22,7 +27,9 @@ pub fn handler(sqs: SqsClient, queue_name: &str) -> Result<Vec<String>, Box<dyn 
           let deleted = delete_message(&sqs, queue_name, receipt.into());
           match deleted {
             Ok(()) => {
-              println!("Deleted message: {}", msg.body.unwrap_or("NO MESSAGE FOUND".into()));
+              let text_to_write = msg.body.unwrap_or("NO MESSAGE FOUND".into());
+              write!(output, "{}\n\n", text_to_write);
+              println!("Deleted message: {}", text_to_write);
             },
             _ => {
               println!("Failed to delete message: {}", msg.body.unwrap_or("NO MESSAGE FOUND".into()));

--- a/src/commands/sqs/list_message.rs
+++ b/src/commands/sqs/list_message.rs
@@ -1,0 +1,66 @@
+use std::error::Error;
+use std::env;
+use rusoto_sqs::*;
+use super::models::Message::RawsMessage;
+
+fn construct_queue_url(queue_name: &str) -> Result<String, Box<dyn Error>> {
+  Ok(String::from(format!(
+      "https://sqs.{region}.amazonaws.com/{account}/{queue_name}",
+      region = env::var("AWS_DEFAULT_REGION").expect("AWS REGION NOT FOUND"),
+      account = env::var("AWS_ACCOUNT").expect("AWS ACCOUNT NOT FOUND"),
+      queue_name = queue_name
+  )))
+}
+
+fn retrieve_messages(client: &SqsClient, request: &ReceiveMessageRequest) -> Result<Vec<RawsMessage>, Box<dyn Error>> {
+  Ok(client
+      .receive_message(request.clone())
+      .sync()?
+      .messages
+      .unwrap_or_default()
+      .iter()
+      .filter_map(|message: &Message| {
+          let aws_message = message.clone();
+          Some(RawsMessage::create(
+              aws_message.body,
+              aws_message.message_id,
+              aws_message.receipt_handle
+          ))
+      })
+      .collect::<Vec<RawsMessage>>()
+  )
+}
+
+fn retrieve_all_messages(client: &SqsClient, request: &ReceiveMessageRequest, result: Vec<RawsMessage>) -> Vec<RawsMessage> {
+  let msgs = retrieve_messages(client, request);
+  // if Err or Vec is empty, return result
+  // otherwise, call retrieve_all_messages passing results + Vec
+  match msgs {
+      Ok(v) => {
+          if v.is_empty() {
+              result
+          } else {
+              let new_result = result.into_iter().chain(v.into_iter()).collect();
+              retrieve_all_messages(&client, &request, new_result)
+          }
+      },
+      Err(e) => {
+          println!("An error occurred: {}", e);
+          result
+      }
+  }
+}
+
+// Example: "https://sqs.ap-southeast-2.amazonaws.com/954088256298/rust-aws-integration"
+pub fn handler(sqs: SqsClient, queue_name: &str) -> Result<Vec<String>, Box<dyn Error>> {
+  let request = ReceiveMessageRequest {
+      queue_url: construct_queue_url(queue_name)?,
+      max_number_of_messages: Some(10),
+      ..Default::default()
+  };
+  let messages = retrieve_all_messages(&sqs, &request, vec!())
+      .iter()
+      .map(|msg| format!("{}", msg))
+      .collect::<Vec<String>>();
+  Ok(messages)
+}

--- a/src/commands/sqs/list_message.rs
+++ b/src/commands/sqs/list_message.rs
@@ -1,16 +1,7 @@
 use std::error::Error;
-use std::env;
 use rusoto_sqs::*;
 use super::models::Message::RawsMessage;
-
-fn construct_queue_url(queue_name: &str) -> Result<String, Box<dyn Error>> {
-  Ok(String::from(format!(
-      "https://sqs.{region}.amazonaws.com/{account}/{queue_name}",
-      region = env::var("AWS_DEFAULT_REGION").expect("AWS REGION NOT FOUND"),
-      account = env::var("AWS_ACCOUNT").expect("AWS ACCOUNT NOT FOUND"),
-      queue_name = queue_name
-  )))
-}
+use super::common::construct_queue_url;
 
 fn retrieve_messages(client: &SqsClient, request: &ReceiveMessageRequest) -> Result<Vec<RawsMessage>, Box<dyn Error>> {
   Ok(client
@@ -31,7 +22,7 @@ fn retrieve_messages(client: &SqsClient, request: &ReceiveMessageRequest) -> Res
   )
 }
 
-fn retrieve_all_messages(client: &SqsClient, request: &ReceiveMessageRequest, result: Vec<RawsMessage>) -> Vec<RawsMessage> {
+pub fn retrieve_all_messages(client: &SqsClient, request: &ReceiveMessageRequest, result: Vec<RawsMessage>) -> Vec<RawsMessage> {
   let msgs = retrieve_messages(client, request);
   // if Err or Vec is empty, return result
   // otherwise, call retrieve_all_messages passing results + Vec

--- a/src/commands/sqs/list_message.rs
+++ b/src/commands/sqs/list_message.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use rusoto_sqs::*;
-use super::models::Message::RawsMessage;
+use super::models::message::RawsMessage;
 use super::common::construct_queue_url;
 
 fn retrieve_messages(client: &SqsClient, request: &ReceiveMessageRequest) -> Result<Vec<RawsMessage>, Box<dyn Error>> {
@@ -10,7 +10,7 @@ fn retrieve_messages(client: &SqsClient, request: &ReceiveMessageRequest) -> Res
       .messages
       .unwrap_or_default()
       .iter()
-      .filter_map(|message: &Message| {
+      .flat_map(|message: &Message| {
           let aws_message = message.clone();
           Some(RawsMessage::create(
               aws_message.body,

--- a/src/commands/sqs/list_queue.rs
+++ b/src/commands/sqs/list_queue.rs
@@ -1,0 +1,16 @@
+use rusoto_core::RusotoError;
+use rusoto_sqs::*;
+
+pub fn handler(sqs: SqsClient) -> Result<Vec<String>, RusotoError<ListQueuesError>> {
+  let request = ListQueuesRequest::default();
+  Ok(sqs
+      .list_queues(request)
+      .sync()?
+      .queue_urls
+      .unwrap_or_default()
+      .iter()
+      .map(|url| url.split("/").last().map(|x| x.into()))
+      .filter_map(|m| m)
+      .collect::<Vec<String>>()
+  )
+}

--- a/src/commands/sqs/list_queue.rs
+++ b/src/commands/sqs/list_queue.rs
@@ -9,8 +9,7 @@ pub fn handler(sqs: SqsClient) -> Result<Vec<String>, RusotoError<ListQueuesErro
       .queue_urls
       .unwrap_or_default()
       .iter()
-      .map(|url| url.split("/").last().map(|x| x.into()))
-      .filter_map(|m| m)
+      .flat_map(|url| url.split('/').last().map(|x| x.into()))
       .collect::<Vec<String>>()
   )
 }

--- a/src/commands/sqs/mod.rs
+++ b/src/commands/sqs/mod.rs
@@ -1,0 +1,1 @@
+pub mod models;

--- a/src/commands/sqs/mod.rs
+++ b/src/commands/sqs/mod.rs
@@ -1,3 +1,5 @@
 pub mod models;
 pub mod list_queue;
 pub mod list_message;
+pub mod download_message;
+mod common;

--- a/src/commands/sqs/mod.rs
+++ b/src/commands/sqs/mod.rs
@@ -1,1 +1,3 @@
 pub mod models;
+pub mod list_queue;
+pub mod list_message;

--- a/src/commands/sqs/models/Message.rs
+++ b/src/commands/sqs/models/Message.rs
@@ -1,0 +1,31 @@
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct RawsMessage {
+  body: Option<String>,
+  message_id: Option<String>,
+  receipt_handle: Option<String>
+}
+
+impl RawsMessage {
+  pub fn create(
+    body: Option<String>,
+    message_id: Option<String>,
+    receipt_handle: Option<String>
+  ) -> RawsMessage {
+    RawsMessage {
+      body,
+      message_id,
+      receipt_handle
+    }
+  }
+}
+
+impl fmt::Display for RawsMessage {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match &self.body {
+      Some(txt) => write!(f, "{}", txt),
+      None => write!(f, "")
+    }
+  }
+}

--- a/src/commands/sqs/models/Message.rs
+++ b/src/commands/sqs/models/Message.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 #[derive(Debug, Clone)]
 pub struct RawsMessage {
-  body: Option<String>,
+  pub body: Option<String>,
   message_id: Option<String>,
   pub receipt_handle: Option<String>
 }

--- a/src/commands/sqs/models/Message.rs
+++ b/src/commands/sqs/models/Message.rs
@@ -4,7 +4,7 @@ use std::fmt;
 pub struct RawsMessage {
   body: Option<String>,
   message_id: Option<String>,
-  receipt_handle: Option<String>
+  pub receipt_handle: Option<String>
 }
 
 impl RawsMessage {

--- a/src/commands/sqs/models/mod.rs
+++ b/src/commands/sqs/models/mod.rs
@@ -1,0 +1,1 @@
+pub mod Message;

--- a/src/commands/sqs/models/mod.rs
+++ b/src/commands/sqs/models/mod.rs
@@ -1,1 +1,1 @@
-pub mod Message;
+pub mod message;

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,27 @@ fn sqs_subcommand_handler(
     }
 }
 
+fn output_formatter(output: Vec<String>) -> String {
+    let padding_size = 2;
+    let max_length = output
+        .iter()
+        .fold(0, |acc, item| {
+            if (item.len()) > acc
+                {item.len() + padding_size}
+            else {acc}
+        });
+    let delimiter = "-".repeat(max_length);
+    output
+        .iter()
+        .fold(format!("|{}|", delimiter), |acc, item| {
+            let right_empty_space = max_length - item.len();
+            let right_filler = if right_empty_space > padding_size
+                {" ".repeat(right_empty_space - padding_size)}
+            else {"".into()};
+            format!("{}\n| {} {}|\n|{}|", acc, item, right_filler, delimiter)
+        })
+}
+
 fn main() {
     let authors: &str = &vec!["Justin Lam", "Paolo Napolitano"].join(", ");
     let matches = App::new("raws")
@@ -64,9 +85,12 @@ fn main() {
         match sqs_subcommand_handler(sqs, sqs_matches) {
             Err(e) => {
                 dbg!(e);
-                ()
             }
-            Ok(result) => println!("{:?}", result),
+            Ok(result) => {
+                if result.is_empty()
+                {println!("No results")}
+                else {println!("{}", output_formatter(result))}
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use rusoto_sqs::*;
 use std::error::Error;
 
 mod commands;
-use commands::sqs::{list_message, list_queue};
+use commands::sqs::{ list_message, list_queue, download_message };
 
 fn sqs_subcommand_handler(
     sqs: SqsClient,
@@ -19,6 +19,14 @@ fn sqs_subcommand_handler(
             sqs,
             arg_matches
                 .subcommand_matches("list-messages")
+                .unwrap()
+                .value_of("queue-name")
+                .expect("Queue name not provided"),
+        )?),
+        Some("download-messages") => Ok(download_message::handler(
+            sqs,
+            arg_matches
+                .subcommand_matches("download-messages")
                 .unwrap()
                 .value_of("queue-name")
                 .expect("Queue name not provided"),
@@ -40,7 +48,10 @@ fn main() {
                     SubCommand::with_name("list-messages")
                         .arg(Arg::with_name("queue-name").required(true).index(1)),
                 )
-                .subcommand(SubCommand::with_name("download-messages")),
+                .subcommand(
+                    SubCommand::with_name("download-messages")
+                        .arg(Arg::with_name("queue-name").required(true).index(1)),
+                )
         )
         .get_matches();
     let sqs = SqsClient::new(Region::ApSoutheast2);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,10 @@ fn sqs_subcommand_handler(
                 .unwrap()
                 .value_of("queue-name")
                 .expect("Queue name not provided"),
+            arg_matches
+                .subcommand_matches("download-messages")
+                .unwrap()
+                .is_present("delete")
         )?),
         _ => unimplemented!(),
     }
@@ -50,7 +54,8 @@ fn main() {
                 )
                 .subcommand(
                     SubCommand::with_name("download-messages")
-                        .arg(Arg::with_name("queue-name").required(true).index(1)),
+                        .arg(Arg::with_name("queue-name").required(true).index(1))
+                        .arg(Arg::from_usage("--delete").allow_hyphen_values(true)),
                 )
         )
         .get_matches();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,21 @@
 use clap::{App, Arg, ArgMatches, SubCommand};
-use rusoto_core::{Region, RusotoError};
+use rusoto_core::Region;
 use rusoto_sqs::*;
-use std::env;
 use std::error::Error;
 
 mod commands;
-use commands::sqs::models::Message::RawsMessage;
+use commands::sqs::{list_message, list_queue};
 
 fn sqs_subcommand_handler(
     sqs: SqsClient,
     arg_matches: &ArgMatches<'_>,
 ) -> Result<Vec<String>, Box<dyn Error>> {
+    // list-queues
+    // list-messages <queue-url>
+    // download-messages <queue-url>
     match arg_matches.subcommand_name() {
-        Some("list-queues") => Ok(list_queue_handler(sqs)?),
-        Some("list-messages") => Ok(list_message_handler(
+        Some("list-queues") => Ok(list_queue::handler(sqs)?),
+        Some("list-messages") => Ok(list_message::handler(
             sqs,
             arg_matches
                 .subcommand_matches("list-messages")
@@ -23,82 +25,6 @@ fn sqs_subcommand_handler(
         )?),
         _ => unimplemented!(),
     }
-}
-
-fn list_queue_handler(sqs: SqsClient) -> Result<Vec<String>, RusotoError<ListQueuesError>> {
-    let request = ListQueuesRequest::default();
-    Ok(sqs
-        .list_queues(request)
-        .sync()?
-        .queue_urls
-        .unwrap_or_default()
-        .iter()
-        .map(|url| url.split("/").last().map(|x| x.into()))
-        .filter_map(|m| m)
-        .collect::<Vec<String>>()
-    )
-}
-
-fn construct_queue_url(queue_name: &str) -> Result<String, Box<dyn Error>> {
-    Ok(String::from(format!(
-        "https://sqs.{region}.amazonaws.com/{account}/{queue_name}",
-        region = env::var("AWS_DEFAULT_REGION").expect("AWS REGION NOT FOUND"),
-        account = env::var("AWS_ACCOUNT").expect("AWS ACCOUNT NOT FOUND"),
-        queue_name = queue_name
-    )))
-}
-
-fn retrieve_messages(client: &SqsClient, request: &ReceiveMessageRequest) -> Result<Vec<RawsMessage>, Box<dyn Error>> {
-    Ok(client
-        .receive_message(request.clone())
-        .sync()?
-        .messages
-        .unwrap_or_default()
-        .iter()
-        .filter_map(|message: &Message| {
-            let aws_message = message.clone();
-            Some(RawsMessage::create(
-                aws_message.body,
-                aws_message.message_id,
-                aws_message.receipt_handle
-            ))
-        })
-        .collect::<Vec<RawsMessage>>()
-    )
-}
-
-fn retrieve_all_messages(client: &SqsClient, request: &ReceiveMessageRequest, result: Vec<RawsMessage>) -> Vec<RawsMessage> {
-    let msgs = retrieve_messages(client, request);
-    // if Err or Vec is empty, return result
-    // otherwise, call retrieve_all_messages passing results + Vec
-    match msgs {
-        Ok(v) => {
-            if v.is_empty() {
-                result
-            } else {
-                let new_result = result.into_iter().chain(v.into_iter()).collect();
-                retrieve_all_messages(&client, &request, new_result)
-            }
-        },
-        Err(e) => {
-            println!("An error occurred: {}", e);
-            result
-        }
-    }
-}
-
-// "https://sqs.ap-southeast-2.amazonaws.com/954088256298/rust-aws-integration"
-fn list_message_handler(sqs: SqsClient, queue_name: &str) -> Result<Vec<String>, Box<dyn Error>> {
-    let request = ReceiveMessageRequest {
-        queue_url: construct_queue_url(queue_name)?,
-        max_number_of_messages: Some(10),
-        ..Default::default()
-    };
-    let messages = retrieve_all_messages(&sqs, &request, vec!())
-        .iter()
-        .map(|msg| format!("{}", msg))
-        .collect::<Vec<String>>();
-    Ok(messages)
 }
 
 fn main() {
@@ -117,10 +43,6 @@ fn main() {
                 .subcommand(SubCommand::with_name("download-messages")),
         )
         .get_matches();
-
-    // list-queues
-    // list-messages <queue-url>
-    // download-messages <queue-url>
     let sqs = SqsClient::new(Region::ApSoutheast2);
     if let Some(sqs_matches) = matches.subcommand_matches("sqs") {
         match sqs_subcommand_handler(sqs, sqs_matches) {
@@ -131,49 +53,4 @@ fn main() {
             Ok(result) => println!("{:?}", result),
         }
     }
-    // match sqs_matches.subcommand_name() {
-    //     Some("list-queues") => {
-    //         let request = ListQueuesRequest::default();
-    //         let result = sqs.list_queues(request).sync();
-    //         match result {
-    //             Ok(list_queues_results) => list_queues_results
-    //                 .queue_urls
-    //                 .unwrap_or_default()
-    //                 .iter()
-    //                 .map(|url| url.split("/").last().unwrap_or_default())
-    //                 .map(|name| println!("{}", name))
-    //                 .collect(),
-    //             // TODO extract the Message from the error
-    //             Err(rusoto_error) => {
-    //                 dbg!(rusoto_error);
-    //             }
-    //         }
-    //     }
-    //     Some("list-messages") => {
-    //         let request = ReceiveMessageRequest{
-    //             queue_url: String::from("https://sqs.ap-southeast-2.amazonaws.com/954088256298/rust-aws-integration"),
-    //             max_number_of_messages: Some(10),
-    //             ..Default::default()
-    //         };
-    //         let result = sqs.receive_message(request).sync();
-    //         match result {
-    //             Ok(message_results) => message_results
-    //                 .messages
-    //                 .unwrap_or_default()
-    //                 .iter()
-    //                 .map(|message| {
-    //                     if let Some(x) = &message.body {
-    //                         println!("{}", x);
-    //                     }
-    //                 })
-    //                 .collect(),
-    //             Err(rusoto_error) => {
-    //                 dbg!(rusoto_error);
-    //             }
-    //         }
-    //     },
-    //     Some("download-messages") => println!("download-messages"),
-    //     _ => println!("NOT ALLOWED"),
-    // }
-    // }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,9 @@ use rusoto_sqs::*;
 use std::error::Error;
 
 mod commands;
+mod output;
 use commands::sqs::{ list_message, list_queue, download_message };
+use output::formatters::output_formatter;
 
 fn sqs_subcommand_handler(
     sqs: SqsClient,
@@ -37,27 +39,6 @@ fn sqs_subcommand_handler(
         )?),
         _ => unimplemented!(),
     }
-}
-
-fn output_formatter(output: Vec<String>) -> String {
-    let padding_size = 2;
-    let max_length = output
-        .iter()
-        .fold(0, |acc, item| {
-            if (item.len()) > acc
-                {item.len() + padding_size}
-            else {acc}
-        });
-    let delimiter = "-".repeat(max_length);
-    output
-        .iter()
-        .fold(format!("|{}|", delimiter), |acc, item| {
-            let right_empty_space = max_length - item.len();
-            let right_filler = if right_empty_space > padding_size
-                {" ".repeat(right_empty_space - padding_size)}
-            else {"".into()};
-            format!("{}\n| {} {}|\n|{}|", acc, item, right_filler, delimiter)
-        })
 }
 
 fn main() {

--- a/src/output/formatters.rs
+++ b/src/output/formatters.rs
@@ -1,0 +1,20 @@
+pub fn output_formatter(output: Vec<String>) -> String {
+  let padding_size = 2;
+  let max_length = output
+      .iter()
+      .fold(0, |acc, item| {
+          if (item.len()) > acc
+              {item.len() + padding_size}
+          else {acc}
+      });
+  let delimiter = "-".repeat(max_length);
+  output
+      .iter()
+      .fold(format!("|{}|", delimiter), |acc, item| {
+          let right_empty_space = max_length - item.len();
+          let right_filler = if right_empty_space > padding_size
+              {" ".repeat(right_empty_space - padding_size)}
+          else {"".into()};
+          format!("{}\n| {} {}|\n|{}|", acc, item, right_filler, delimiter)
+      })
+}

--- a/src/output/formatters.rs
+++ b/src/output/formatters.rs
@@ -4,17 +4,35 @@ pub fn output_formatter(output: Vec<String>) -> String {
       .iter()
       .fold(0, |acc, item| {
           if (item.len()) > acc
-              {item.len() + padding_size}
+              {item.len()}
           else {acc}
       });
-  let delimiter = "-".repeat(max_length);
+  let delimiter = "-".repeat(max_length + padding_size);
   output
       .iter()
       .fold(format!("|{}|", delimiter), |acc, item| {
           let right_empty_space = max_length - item.len();
-          let right_filler = if right_empty_space > padding_size
-              {" ".repeat(right_empty_space - padding_size)}
+          let right_filler = if right_empty_space > 0
+              {" ".repeat(right_empty_space)}
           else {"".into()};
           format!("{}\n| {} {}|\n|{}|", acc, item, right_filler, delimiter)
       })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_an_empty_vector() {
+        let expected = "|--|";
+        assert_eq!(output_formatter(vec!()), expected);
+    }
+
+    #[test]
+    fn test_format_mix_length() {
+        let strings = vec!("6 char".into(), "8 chars-".into());
+        let expected = "|----------|\n| 6 char   |\n|----------|\n| 8 chars- |\n|----------|";
+        assert_eq!(output_formatter(strings), expected);
+    }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,0 +1,2 @@
+pub mod formatters;
+pub mod writers;

--- a/src/output/writers.rs
+++ b/src/output/writers.rs
@@ -1,0 +1,9 @@
+use std::io::Write;
+use std::fs::File;
+
+pub fn write_to_file(mut output: &File, text_to_write: &str) {
+  match write!(output, "{}\n\n", text_to_write) {
+    Ok(_) => (),
+    Err(e) => println!("Failed to write tio file, with error: {}", e)
+  }
+}

--- a/src/output/writers.rs
+++ b/src/output/writers.rs
@@ -4,6 +4,6 @@ use std::fs::File;
 pub fn write_to_file(mut output: &File, text_to_write: &str) {
   match write!(output, "{}\n\n", text_to_write) {
     Ok(_) => (),
-    Err(e) => println!("Failed to write tio file, with error: {}", e)
+    Err(e) => println!("Failed to write to file, with error: {}", e)
   }
 }


### PR DESCRIPTION
# What
- Download all messages off a queue
- Saves them to file
- Has an option to delete them

# Why
- We want the ability to get a message off a queue, delete it and re-play it

# How
- Getting the messages
- For each one of them, printing and storing on file
- Then deleting it using the receipt handle if the `--delete` option is passed